### PR TITLE
Updated to use python3 commands with modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Start a python virtual env:
 cd flask-pymongo-example
 
 # create the virtual environment for MFlix
-virtualenv -p YOUR_LOCAL_PYTHON3_PATH mflix_venv
+python3 -m venv mflix-venv
 
 # activate the virtual environment
 source mflix_venv/bin/activate
@@ -74,7 +74,7 @@ source mflix_venv/bin/activate
 
 Install dependencies
 ```
-pip install -r requirments.txt
+python3 -m pip install -r requirments.txt
 ```
 
 Rename the `sample_ini` to `.ini`.


### PR DESCRIPTION
Issues addressed:
1. Virtualenv wasn't a command in my terminal out of the box
2. When doing things with a python repo previously, I found issues with an existing pip install outside of python3 that was the wrong version

Solution:
- Update the commands to use python3 as the main command, as this works out of the box