### PR TITLE
Typo Fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ source mflix_venv/bin/activate
 
 Install dependencies
 ```
-python3 -m pip install -r requirments.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Rename the `sample_ini` to `.ini`.


### PR DESCRIPTION
There is a typo in README.md,
requirments.txt => requirements.txt