### PR TITLE
Correct Installation Instructions for Activiting Virual Environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd flask-pymongo-example
 python3 -m venv mflix-venv
 
 # activate the virtual environment
-source mflix_venv/bin/activate
+source mflix-venv/bin/activate
 ```
 
 Install dependencies

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ source mflix-venv/bin/activate
 
 Install dependencies
 ```
-python3 -m pip install -r requirments.txt
+python3 -m pip install -r requirements.txt
 ```
 
 Rename the `sample_ini` to `.ini`.


### PR DESCRIPTION
The installation instructions walk through the creation of the virtual environment in directory `mflex_venv`, but then instruct the user to activate the virtual environment in the directory `mflex-venv`. This should be corrected to prevent confusion, especially for beginner programmers.